### PR TITLE
Correct Rochester NY vs Rochester MN

### DIFF
--- a/nielsentopo.json
+++ b/nielsentopo.json
@@ -6935,7 +6935,7 @@
             "latitude": 42.9137715,
             "tvperc": 87.6,
             "dma": 538,
-            "dma1": "Rochester, MN-Mason City, IA-Austin, MN",
+            "dma1": "Rochester, NY",
             "cableperc": 69.5,
             "adsperc": 18.6,
             "longitude": -77.387152
@@ -6961,7 +6961,7 @@
             "latitude": 43.552183,
             "tvperc": 89,
             "dma": 611,
-            "dma1": "Rochester, NY",
+            "dma1": "Rochester, MN-Mason City, IA-Austin, MN",
             "cableperc": 57,
             "adsperc": 32.4,
             "longitude": -92.850969


### PR DESCRIPTION
The Rochester NY and Rochester MN data are switched. According to http://www.stssamples.com/dma-codes.asp, Rochester NY's DMA ID is 538 and Rochester-Mason City-Austin's DMA ID is 611.